### PR TITLE
Fix the problem with "upstream sent too big header while reading response header from upstream"

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -62,7 +62,6 @@ http {
 
     # HTTP 1.1 support
     proxy_http_version  1.1;
-    proxy_buffering     off;
     proxy_set_header    Host $http_host;
     proxy_set_header    Upgrade $http_upgrade;
     proxy_set_header    Connection $proxy_connection;
@@ -83,7 +82,9 @@ http {
     
     fastcgi_buffers 16 16k; 
     fastcgi_buffer_size 32k;
-    proxy_buffering off;
+    proxy_buffer_size   128k;
+    proxy_buffers   4 256k;
+    proxy_busy_buffers_size   256k;
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -73,6 +73,10 @@ http {
     client_max_body_size 500M;
     # Allow long running scripts
     proxy_read_timeout 600s;
+    # Disable output response body bufferring
+    proxy_buffering off;
+    # Increase output response headers buffer size (this is separate from proxy_buffering, defaults to 4k)
+    proxy_buffer_size 16k;
 
     # Fixes random issues with POST requests
     # See https://github.com/dockerfile/nginx/issues/4#issuecomment-209440995
@@ -80,11 +84,5 @@ http {
     client_body_buffer_size 256k;
     client_body_in_file_only off;
     
-    fastcgi_buffers 16 16k; 
-    fastcgi_buffer_size 32k;
-    proxy_buffer_size   128k;
-    proxy_buffers   4 256k;
-    proxy_busy_buffers_size   256k;
-
     include /etc/nginx/conf.d/*.conf;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -80,8 +80,10 @@ http {
     client_body_temp_path /tmp 1 2;
     client_body_buffer_size 256k;
     client_body_in_file_only off;
+    
     fastcgi_buffers 16 16k; 
     fastcgi_buffer_size 32k;
+    proxy_buffering off;
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -80,6 +80,8 @@ http {
     client_body_temp_path /tmp 1 2;
     client_body_buffer_size 256k;
     client_body_in_file_only off;
+    fastcgi_buffers 16 16k; 
+    fastcgi_buffer_size 32k;
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -83,6 +83,6 @@ http {
     client_body_temp_path /tmp 1 2;
     client_body_buffer_size 256k;
     client_body_in_file_only off;
-    
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Sometimes Drupal may send header that are too long. 
This happens for instance when `http.response.debug_cacheability_headers` are set to `true`.
vhost-proxy fails to proxy requests in this case.

Despite [answer here](http://stackoverflow.com/a/27551259/1359178) says that disabled buffers also work the truth is only buffers work (checked on local with setup where I can replicate the issue).
