### PR TITLE
Release v1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ env:
   PROJECT_INACTIVITY_TIMEOUT: 30s
   PROJECT_DANGLING_TIMEOUT: 60s
   PROXY_DEBUG: 1
+  DOCKSAL_VERSION: master
 
 services:
   - docker
 
 install:
-  - sudo sudo curl -L https://raw.githubusercontent.com/docksal/docksal/develop/bin/fin -o /usr/local/bin/fin && sudo chmod +x /usr/local/bin/fin
+  - sudo sudo curl -L https://raw.githubusercontent.com/docksal/docksal/${DOCKSAL_VERSION}/bin/fin -o /usr/local/bin/fin && sudo chmod +x /usr/local/bin/fin
   - fin version
   - fin update
   - fin docker build -t ${IMAGE_VHOST_PROXY} .

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -62,7 +62,6 @@ http {
 
     # HTTP 1.1 support
     proxy_http_version  1.1;
-    proxy_buffering     off;
     proxy_set_header    Host $http_host;
     proxy_set_header    Upgrade $http_upgrade;
     proxy_set_header    Connection $proxy_connection;
@@ -74,6 +73,10 @@ http {
     client_max_body_size 500M;
     # Allow long running scripts
     proxy_read_timeout 600s;
+    # Disable output response body bufferring
+    proxy_buffering off;
+    # Increase output response headers buffer size (this is separate from proxy_buffering, defaults to 4k)
+    proxy_buffer_size 16k;
 
     # Fixes random issues with POST requests
     # See https://github.com/dockerfile/nginx/issues/4#issuecomment-209440995


### PR DESCRIPTION
- Fix "upstream sent too big header while reading response header from upstream" (#12)
- Fix tests on TravisCI