### PR TITLE
Allow usage of own certificate per project + HTTP-->HTTPS redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --res
 `PROXY_DEBUG`
 
 Set to `1` to enable debug logging. Check logs with `docker logs docksal-vhost-proxy`.
+
+#### Own certificates
+
+You can use your own SSL certificate per project. For this to work make sure your
+projects are bind to /projects folder (i.e via docksal_projects) and contains 
+```
+certs/server.key
+certs/server.crt
+```
+owned by user 0 in root of your project.
+
+##### Redirect HTTP to HTTPS
+Put an empty file called `https_only` in the same directory (`certs/https_only`)
+to make redirect http requests to HTTPS. For the redirect, the first
+given domain in the label `io.docksal.virtual-host` will be used.
+

--- a/conf/nginx/default.conf.tmpl
+++ b/conf/nginx/default.conf.tmpl
@@ -156,7 +156,9 @@
 		{{ template "http" (dict "Hosts" $host "Upstream" $host) }}
 
 		{{ if (and (exists "/etc/nginx/server.crt") (exists "/etc/nginx/server.key")) }}
-			{{ template "https" (dict "Hosts" $host "Upstream" $host) }}
+      {{ $cert := "/etc/nginx/server.crt" }}
+      {{ $cert_key := "/etc/nginx/server.key" }}
+			{{ template "https" (dict "Hosts" $host "Upstream" $host "Cert" $cert "CertKey" $cert_key) }}
 		{{ end }}
 
 	{{ end }}

--- a/conf/nginx/default.conf.tmpl
+++ b/conf/nginx/default.conf.tmpl
@@ -31,6 +31,17 @@
 	}
 {{ end }}
 
+{{ define "http_redirect" }}
+	# HTTP Redirect to HTTPS
+	server {
+		listen 80;
+		{{ range $host := split .Hosts "," }}
+			server_name {{ $host }};
+		{{ end }}
+		return 307 https://{{ index (split .Hosts ",") 0 }}$request_uri;
+	}
+{{ end }}
+
 {{ define "https" }}
 	# HTTPS
 	server {
@@ -40,8 +51,8 @@
 			server_name {{ $host }};
 		{{ end }}
 
-		ssl_certificate           /etc/nginx/server.crt;
-		ssl_certificate_key       /etc/nginx/server.key;
+		ssl_certificate           {{ .Cert }};
+		ssl_certificate_key       {{ .CertKey }};
 
 		ssl on;
 		ssl_session_cache  builtin:1000  shared:SSL:10m;
@@ -88,10 +99,23 @@
 		{{ end }}
 		}
 
-		{{ template "http" (dict "Hosts" $hosts "Upstream" $upstream) }}
+		{{ $pot_redirect := (print "/projects/" $project "/certs/https_only") }}
+		{{ if (exists $pot_redirect) }}
+			{{ template "http_redirect" (dict "Hosts" $hosts) }}
+		{{ else }}
+			{{ template "http" (dict "Hosts" $hosts "Upstream" $upstream) }}
+		{{ end }}
 
-		{{ if (and (exists "/etc/nginx/server.crt") (exists "/etc/nginx/server.key")) }}
-			{{ template "https" (dict "Hosts" $hosts "Upstream" $upstream) }}
+		{{ $pot_key := (print "/projects/" $project "/certs/server.key") }}
+		{{ $pot_crt := (print "/projects/" $project "/certs/server.crt") }}
+		{{ if (and (exists $pot_crt) (exists $pot_key)) }}
+			{{ $cert := $pot_crt }}
+			{{ $cert_key := $pot_key }}
+			{{ template "https" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert "CertKey" $cert_key) }}
+		{{ else if (and (exists "/etc/nginx/server.crt") (exists "/etc/nginx/server.key")) }}
+			{{ $cert := "/etc/nginx/server.crt" }}
+			{{ $cert_key := "/etc/nginx/server.key" }}
+			{{ template "https" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert "CertKey" $cert_key) }}
 		{{ end }}
 
 	{{ end }}


### PR DESCRIPTION
- Defined new template for redirecting HTTP to HTTPS. Which is used when there is a https_only file in projects /certs folder.
- Adjusted template to use a specific certificate for the project, when there is one.
- Adjusted README with instructions how to use this.

HTTP Redirect takes the first domain in the io.docksal.virtual-host config.
Probably thats not the best idea when thinking of multidomain sites. Instead one could use $host variable of nginx. 
But then one could not do things like redirecting domain.tld to https://www.domain.tld, which was the usecase for us so it is implemented like this. 
Needs some improvement here for multidomain sites (or redirect there could be done in apache level via .htaccess instead of directly in the proxy).