### PR TITLE
Increase proxy_buffer_size for projects with large header size

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -76,7 +76,7 @@ http {
     # Disable output response body bufferring
     proxy_buffering off;
     # Increase output response headers buffer size (this is separate from proxy_buffering, defaults to 4k)
-    proxy_buffer_size 8k;
+    proxy_buffer_size 16k;
 
     # Fixes random issues with POST requests
     # See https://github.com/dockerfile/nginx/issues/4#issuecomment-209440995


### PR DESCRIPTION
Drupal 8 sets cache tags headers and cache contexts that can exceed the limit of 8k very easily. I propose to increase it to 16k at least