### PR TITLE
Release 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,9 @@ ENV \
 	# Disable debug output by default
 	DEBUG_LOG=0 \
 	# Disable stats log by default
-	STATS_LOG=0
+	STATS_LOG=0 \
+	# Default domain
+	DEFAULT_CERT=docksal
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine
+FROM openresty/openresty:1.13.6.2-1-alpine
 
 RUN set -xe; \
 	apk add --update --no-cache \
@@ -13,9 +13,9 @@ RUN set -xe; \
 	addgroup -S nginx; \
 	adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 
-ARG DOCKER_VERSION=18.03.1-ce
+ARG DOCKER_VERSION=18.06.1-ce
 ARG DOCKER_GEN_VERSION=0.7.4
-ARG GOMPLATE_VERSION=2.6.0
+ARG GOMPLATE_VERSION=3.0.0
 
 # Install docker client binary (if not mounting binary from host)
 RUN set -xe; \

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ push:
 	docker push $(REPO):$(VERSION)
 
 exec:
-	docker exec $(NAME) $(CMD)
+	@docker exec $(NAME) $(CMD)
 
 exec-it:
-	docker exec -it $(NAME) $(CMD)
+	@docker exec -it $(NAME) $(CMD)
 
 shell:
-	make exec -e CMD=bash
+	@make exec-it -e CMD=bash
 
 conf-vhosts:
 	make exec -e CMD='cat /etc/nginx/conf.d/vhosts.conf'

--- a/README.md
+++ b/README.md
@@ -141,3 +141,19 @@ The following container environment variables can be used to enabled various log
 `STATS_LOG` - Set to `1` to enable project stats logging.
 
 Check logs with `docker logs docksal-vhost-proxy`.
+
+
+## Variable mapping for Docksal
+
+When using this image with Docksal (99% of cases), settings for `vhost-proxy` are set via `$HOME/.docksal/docksal.env`. 
+
+The following variable mappings should be applied:
+
+| Configuration variable        | Variable in `$HOME/.docksal/docksal.env`  |
+| ----------------------------- | ----------------------------------------  |
+| `ACCESS_LOG`                  | `DOCKSAL_VHOST_PROXY_ACCESS_LOG`          |
+| `DEBUG_LOG`                   | `DOCKSAL_VHOST_PROXY_DEBUG_LOG`           |
+| `STATS_LOG`                   | `DOCKSAL_VHOST_PROXY_STATS_LOG`           |
+| `PROJECT_INACTIVITY_TIMEOUT`  | `PROJECT_INACTIVITY_TIMEOUT`              |
+| `PROJECT_DANGLING_TIMEOUT`    | `PROJECT_DANGLING_TIMEOUT`                |
+| `DEFAULT_CERT`                | `DOCKSAL_VHOST_PROXY_DEFAULT_CERT`        |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 
 ## Features
 
-- HTTP/HTTPS virtual host routing
+- HTTP/HTTPS and HTTP/2 virtual host routing
 - On-demand stack starting (upon a HTTP/HTTPS request)
 - Stack stopping after a given period of inactivity
 - Stack cleanup after a given period of inactivity
@@ -97,9 +97,12 @@ docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --res
     docksal/vhost-proxy
 ```
 
-## Using custom certs
+## Default and custom certs for HTTPS
 
-Mount a folder with certs to `/etc/certs/custom`. Certs are looked up by virtual host name. 
+The default server cert is a self-signed cert for `*.docksal`. It allows a HTTPS connection to be established, but will 
+make browsers complain that the cert is not valid. If that's not acceptable, you can use a valid custom cert. 
+
+To use custom certs, mount a folder with certs to `/etc/certs/custom`. Certs are looked up by virtual host name. 
 
 E.g., cert and key for `example.com` (or `*.example.com`) are expected in: 
 
@@ -119,6 +122,15 @@ Example: for `io.docksal.cert-name=shared` the following cert/key will be used:
 
 When multiple domain values are set in `io.docksal.virtual-host`, the first one is considered the primary one and 
 used for certificate lookup. You can also always point to a specific cert with `io.docksal.cert-name`. 
+
+When projects are (re)started over HTTPS, the default virtual host config kicks in first. It uses the default self-signed 
+cert, which would trigger a browser warning, even though the actual virtual host is then served using a valid custom 
+cert. To overcome this issue, you can specify the default custom cert name using the `DEFAULT_CERT` environment variable. 
+
+You can use a single domain or a shared (SNI) cert, just like with other custom certs.
+
+Example: `DEFAULT_CERT=example.com` or `DEFAULT_CERT=shared`  
+
 
 ## Logging and debugging
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Symlink certs for the default virtual host (if the default domain is set)
+if [[ "$DEFAULT_CERT" != "" ]] && [[ "$DEFAULT_CERT" != "docksal" ]]; then
+	if [[ -f /etc/certs/custom/${DEFAULT_CERT}.crt ]] && [[ -f /etc/certs/custom/${DEFAULT_CERT}.key ]]; then
+		echo "Using a custom default certificate: '${DEFAULT_CERT}'"
+		ln -sf /etc/certs/custom/${DEFAULT_CERT}.crt /etc/certs/server.crt
+		ln -sf /etc/certs/custom/${DEFAULT_CERT}.key /etc/certs/server.key
+	else
+		echo "WARNING: Default certificate '${DEFAULT_CERT}' set, but no matching certificate files found in"
+		echo -e "\t/etc/certs/custom/${DEFAULT_CERT}.crt"
+		echo -e "\t/etc/certs/custom/${DEFAULT_CERT}.key"
+	fi
+fi
+
 # Connect networks
 /usr/local/bin/proxyctl networks
 

--- a/conf/nginx/conf.d/vhosts.conf.tmpl
+++ b/conf/nginx/conf.d/vhosts.conf.tmpl
@@ -24,28 +24,12 @@
 	{{ end }}
 {{ end }}
 
-{{/* HTTP server template */}}
-{{ define "http" }}
-	## HTTP
-	server {
-		listen 80;
-		{{ range $host := split .Hosts "," }}
-
-		server_name {{ $host }};
-
-		{{ end }}
-
-		location / {
-			proxy_pass http://{{ .Upstream }};
-		}
-	}
-{{ end }}
-
-{{/* HTTPS server template */}}
-{{ define "https" }}
+{{/* HTTP/HTTPS server template */}}
+{{ define "server" }}
 	## HTTPS
 	server {
 
+		listen 80;
 		listen 443 ssl http2;
 		{{ range $host := split .Hosts "," }}
 
@@ -121,9 +105,6 @@
 		{{ end }}
 	}
 
-		{{/* Generate HTTP server config */}}
-		{{ template "http" (dict "Hosts" $hosts "Upstream" $upstream) }}
-
 		{{/* Get the cert name from io.docksal.cert-name container label */}}
 		{{ $certName := or (index $pr_container.Labels "io.docksal.cert-name") "none" }}
 		{{/* Unset certName if its value us "none" */}}
@@ -140,8 +121,8 @@
 		{{/* Use the cert specified on the container or fallback to the best vhost match */}}
 		{{ $cert := (coalesce $certName $vhostCert) }}
 
-		{{/* Generate HTTPS server config */}}
-		{{ template "https" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert) }}
+		{{/* Generate HTTP/HTTPS server config */}}
+		{{ template "server" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert) }}
 
 	{{ end }}
 	# -------------------------------------------------- #
@@ -181,9 +162,6 @@
 		{{ end }}
 	}
 
-		{{/* Generate HTTP server config */}}
-		{{ template "http" (dict "Hosts" $hosts "Upstream" $upstream) }}
-
 		{{/* Get the cert name from io.docksal.cert-name container label */}}
 		{{ $certName := or (index $container.Labels "io.docksal.cert-name") "none" }}
 		{{/* Unset certName if its value us "none" */}}
@@ -200,8 +178,8 @@
 		{{/* Use the cert specified on the container or fallback to the best vhost match */}}
 		{{ $cert := (coalesce $certName $vhostCert) }}
 
-		{{/* Generate HTTPS server config */}}
-		{{ template "https" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert) }}
+		{{/* Generate HTTP/HTTPS server config */}}
+		{{ template "server" (dict "Hosts" $hosts "Upstream" $upstream "Cert" $cert) }}
 
 {{ end }}
 

--- a/conf/nginx/nginx.conf.tmpl
+++ b/conf/nginx/nginx.conf.tmpl
@@ -30,14 +30,6 @@ http {
 
 	server {
 		listen 80;
-		server_name _; # This is just an invalid value which will never trigger on a real hostname.
-
-		location / {
-			rewrite_by_lua_file conf/lua/proxyctl.lua;
-		}
-	}
-
-	server {
 		listen 443 ssl http2;
 
 		server_name _; # This is just an invalid value which will never trigger on a real hostname.


### PR DESCRIPTION
- Version updates
  - Upstream image: openresty/openresty:1.13.6.2-1-alpine (Alpine 3.8)
  - Docker 18.06.1-ce
  - Gomplate 3.0.0
- Added `DEFAULT_CERT` support
- Muted command output for "make exec/exec-it/shell". Also fixed `make shell`
- Combined HTTP and HTTPS vhost configs
- Updated docs
