### PR TITLE
Optimized healthcheck.sh

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 
-# nginx config is valid
-nginx -t || exit 1
+#set -x  # Print commands
+set -e  # Exit on errors
 
-# supervisor services are running
-if [[ -f /run/supervisord.pid ]]; then
-	supervisorctl status docker-gen | grep RUNNING >/dev/null || exit 1
-	supervisorctl status nginx | grep RUNNING >/dev/null || exit 1
-	supervisorctl status crond | grep RUNNING >/dev/null || exit 1
+# Check nginx config is valid
+echo "Checking nginx configuration..."
+nginx -t
 
-	exit 0
-fi
+# Check supervisor running
+echo "Checking supervisor..."
+# Need to do "|| exit 1" here since "set -e" apparently does not care about tests.
+[[ -f /run/supervisord.pid ]] || exit 1
 
-exit 1
+# Check supervisor controlled services
+# Since "supervisorctl status" is heavy and the healthcheck runs quit often, we use "ps" here
+echo "Checking supervisor services..."
+pslist=$(ps)
+echo ${pslist} | grep docker-gen >/dev/null
+echo ${pslist} | grep "nginx: master process" >/dev/null
+echo ${pslist} | grep "nginx: worker process" >/dev/null
+echo ${pslist} | grep crond >/dev/null


### PR DESCRIPTION
Use "ps" instead of "supervisorctl status" (slow and CPU intensive) to check for running services.

Should address the following issues:

- #44 
- #46 
- docksal/docksal#1032
- docksal/docksal#1037

## Comparison

Current version: runs every 5s, uses `supervisorctl status`

![image](https://user-images.githubusercontent.com/1205005/57033140-fa7ff380-6c00-11e9-90cd-3b331879fddd.png)

Proposed version: runs every 5s, uses `ps | grep`

![image](https://user-images.githubusercontent.com/1205005/57033167-0bc90000-6c01-11e9-931e-1dd6216edb9d.png)

No healthcheck: for reference only

![image](https://user-images.githubusercontent.com/1205005/57033114-ea681400-6c00-11e9-959c-040a84ac76f3.png)
