### PR TITLE
Release 1.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Allow using a different docker binary
 DOCKER ?= docker
 
 VERSION ?= dev

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 
-# nginx config is valid
-nginx -t || exit 1
+#set -x  # Print commands
+set -e  # Exit on errors
 
-# supervisor services are running
-if [[ -f /run/supervisord.pid ]]; then
-	supervisorctl status docker-gen | grep RUNNING >/dev/null || exit 1
-	supervisorctl status nginx | grep RUNNING >/dev/null || exit 1
-	supervisorctl status crond | grep RUNNING >/dev/null || exit 1
+# Check nginx config is valid
+echo "Checking nginx configuration..."
+nginx -t
 
-	exit 0
-fi
+# Check supervisor running
+echo "Checking supervisor..."
+# Need to do "|| exit 1" here since "set -e" apparently does not care about tests.
+[[ -f /run/supervisord.pid ]] || exit 1
 
-exit 1
+# Check supervisor controlled services
+# Since "supervisorctl status" is heavy and the healthcheck runs quit often, we use "ps" here
+echo "Checking supervisor services..."
+pslist=$(ps)
+echo ${pslist} | grep docker-gen >/dev/null
+echo ${pslist} | grep "nginx: master process" >/dev/null
+echo ${pslist} | grep "nginx: worker process" >/dev/null
+echo ${pslist} | grep crond >/dev/null


### PR DESCRIPTION
- Optimized `healthcheck.sh`
  - This addresses major (50-60%) CPU spikes causes by the healthcheck script every 5s (#44, #46, docksal/docksal#1032, docksal/docksal#1037)
