### PR TITLE
Ports project volume cleanup from docksal#1058

### DIFF
--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -264,6 +264,8 @@ cleanup ()
 		# Remove project directory
 		log "Removing directory: $mounted_project_root..."
 		rm -rf "$mounted_project_root"
+		# Remove project volumes. docker volume prune -f does not remove project_root.
+		docker volume ls -q --filter "label=com.docker.compose.project=${project_name}" | xargs docker volume rm -f
 	done <<< "$projects"
 
 	log "Removing dangling images..."

--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -256,6 +256,9 @@ cleanup ()
 		# Remove dangling project containers
 		log "Removing dangling project: ${project_name}..."
 		docker ps -qa --filter "label=com.docker.compose.project=${project_name}" | xargs docker rm -f
+		# Remove project volumes. "docker volume prune" (used below) does not remove the project_root volume.
+		# See https://github.com/moby/moby/issues/40152
+		docker volume ls -q --filter "label=com.docker.compose.project=${project_name}" | xargs docker volume rm -f
 		# Disconnect vhost-proxy from the project network and remove the network.
 		# See https://github.com/docksal/service-vhost-proxy/issues/6 for more details on why this is necessary.
 		local network="${project_name}_default"
@@ -264,9 +267,6 @@ cleanup ()
 		# Remove project directory
 		log "Removing directory: $mounted_project_root..."
 		rm -rf "$mounted_project_root"
-		# Remove project volumes. "docker volume prune" (used below) does not remove the project_root volume.
-		# See https://github.com/moby/moby/issues/40152
-		docker volume ls -q --filter "label=com.docker.compose.project=${project_name}" | xargs docker volume rm -f
 	done <<< "$projects"
 
 	log "Removing dangling images..."

--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -264,7 +264,8 @@ cleanup ()
 		# Remove project directory
 		log "Removing directory: $mounted_project_root..."
 		rm -rf "$mounted_project_root"
-		# Remove project volumes. docker volume prune -f does not remove project_root.
+		# Remove project volumes. "docker volume prune" (used below) does not remove the project_root volume.
+		# See https://github.com/moby/moby/issues/40152
 		docker volume ls -q --filter "label=com.docker.compose.project=${project_name}" | xargs docker volume rm -f
 	done <<< "$projects"
 


### PR DESCRIPTION
# Changes

- All project_root named volumes were leftover after `proxyctl cleanup` ran, even for projects that no longer exist. After discussing with @lmakarov, backporting the change in https://github.com/docksal/docksal/pull/1058/files#diff-41adca34c3eac75ca9453c7cb0634f6aR1285 makes sense to have here.