### PR TITLE
Release 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 
 language: minimal
 

--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -256,6 +256,9 @@ cleanup ()
 		# Remove dangling project containers
 		log "Removing dangling project: ${project_name}..."
 		docker ps -qa --filter "label=com.docker.compose.project=${project_name}" | xargs docker rm -f
+		# Remove project volumes. "docker volume prune" (used below) does not remove the project_root volume.
+		# See https://github.com/moby/moby/issues/40152
+		docker volume ls -q --filter "label=com.docker.compose.project=${project_name}" | xargs docker volume rm -f
 		# Disconnect vhost-proxy from the project network and remove the network.
 		# See https://github.com/docksal/service-vhost-proxy/issues/6 for more details on why this is necessary.
 		local network="${project_name}_default"

--- a/tests/projects/project1/.docksal/docksal.env
+++ b/tests/projects/project1/.docksal/docksal.env
@@ -1,1 +1,1 @@
-DOCKSAL_STACK=none
+

--- a/tests/projects/project2/.docksal/docksal.env
+++ b/tests/projects/project2/.docksal/docksal.env
@@ -1,1 +1,0 @@
-DOCKSAL_STACK=none

--- a/tests/projects/project3/.docksal/docksal.env
+++ b/tests/projects/project3/.docksal/docksal.env
@@ -1,1 +1,0 @@
-DOCKSAL_STACK=none


### PR DESCRIPTION
- Better project volume cleanup (ported from https://github.com/docksal/docksal/pull/1058)
- Fixed tests
- Switched Travis builds to Ubuntu 18.04 (bionic)