### PR TITLE
Return 502 error on empty upstream set

### DIFF
--- a/conf/nginx/conf.d/vhosts.conf.tmpl
+++ b/conf/nginx/conf.d/vhosts.conf.tmpl
@@ -103,6 +103,7 @@
 				{{ end }}
 			{{ end }}
 		{{ end }}
+		# Default disabled upstream. This prevents config errors when there are no upstreams.
 		server localhost:80 down;
 	}
 

--- a/conf/nginx/conf.d/vhosts.conf.tmpl
+++ b/conf/nginx/conf.d/vhosts.conf.tmpl
@@ -103,6 +103,7 @@
 				{{ end }}
 			{{ end }}
 		{{ end }}
+		server localhost:80 down;
 	}
 
 		{{/* Get the cert name from io.docksal.cert-name container label */}}


### PR DESCRIPTION
Fixes: https://github.com/docksal/service-vhost-proxy/issues/61