### PR TITLE
Release 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ ENV \
 	PROJECT_INACTIVITY_TIMEOUT=0 \
 	# Disable DANGLING_TIMEOUT by default
 	PROJECT_DANGLING_TIMEOUT=0 \
+	# Enable PROJECT_AUTOSTART by default
+	PROJECT_AUTOSTART=1 \
 	# Disable access log by default
 	ACCESS_LOG=0 \
 	# Disable debug output by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.15.8.2-6-alpine
+FROM openresty/openresty:1.17.8.1-0-alpine
 
 RUN set -xe; \
 	apk add --update --no-cache \

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker run -d --name=nodejs \
 ## Advanced proxy configuration
 
 These advanced settings can be used in CI sandbox environments and help keep the resource usage down by stopping 
-Docksal project containers after a period of inactivity. Projects are automatically restarting upon a new HTTP request.
+Docksal project containers after a period of inactivity. Projects are automatically restarted upon a new HTTP request (unless `PROJECT_AUTOSTART` is set to `0`, see below.).
 
 `PROJECT_INACTIVITY_TIMEOUT`
 
@@ -107,6 +107,9 @@ environment specific equivalent, e.g. `docksal-ci.env`).
 
 Note: permanent projects will still be put into hibernation according to `PROJECT_INACTIVITY_TIMEOUT`.
 
+`PROJECT_AUTOSTART`
+
+Setting this variable to `0` will disable autostart projects by visiting project url. This option is active by default (set to `1`).
 
 ## Default and custom certs for HTTPS
 

--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -103,6 +103,9 @@ start ()
 	# Set logging prefix for the function and trigger a log entry
 	export LOG_PREFIX='[start]' && log
 
+	# Disable projects autostart in case PROJECT_AUTOSTART set to 0
+	[[ "$PROJECT_AUTOSTART" == 0 ]] && log "WARNING: Projects autostart is disabled." && return 0
+
 	local type=${1}
 	local id=${2}
 

--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -191,8 +191,7 @@ stop ()
 		# See https://github.com/docksal/service-vhost-proxy/issues/6 for more details on why this is necessary.
 		local network="${project_name}_default"
 		# '-I {}' and '{}' can be used to position the argument passed by xargs.
-		xargs -I {} docker network disconnect "$network" {} <<< "$project_containers"
-		docker network disconnect "$network" docksal-vhost-proxy
+		xargs -I {} docker network disconnect -f "$network" {} 1>/dev/null <<< "$(docker ps -aq --no-trunc -f "network=${network}")"
 		docker network rm "$network"
 	done <<< "$running_projects"
 }

--- a/conf/nginx/conf.d/vhosts.conf.tmpl
+++ b/conf/nginx/conf.d/vhosts.conf.tmpl
@@ -103,6 +103,8 @@
 				{{ end }}
 			{{ end }}
 		{{ end }}
+		# Default disabled upstream. This prevents config errors when there are no upstreams.
+		server localhost:80 down;
 	}
 
 		{{/* Get the cert name from io.docksal.cert-name container label */}}

--- a/conf/nginx/lua/proxyctl.lua
+++ b/conf/nginx/lua/proxyctl.lua
@@ -1,12 +1,12 @@
 -- Debug pring helper
-function dpr(message)
+local function dpr(message)
     if (tonumber(os.getenv("DEBUG_LOG")) > 0) then
         ngx.log(ngx.STDERR, "DEBUG: " .. message)
     end
 end
 
 -- Helper function to read a file from disk
-function read_file(path)
+local function read_file(path)
     local open = io.open
     local file = open(path, "rb") -- r read mode and b binary mode
     if not file then return nil end
@@ -16,7 +16,7 @@ function read_file(path)
 end
 
 -- Returns loading.html for HTTP_OK and not-found.html otherwise
-function response(status)
+local function response(status)
     -- Load response body from disk
     -- This used to be done with ngx.location.capture, which does not support HTTP/2 and fails with https requests:
     -- See https://github.com/openresty/lua-nginx-module/issues/1285#issuecomment-376418678
@@ -62,7 +62,7 @@ if (lock_timestamp == 0) then
 
     -- Lanch project start script
     -- os.execute returs multiple values starting with Lua 5.2
-    local status, exit, exit_code = os.execute("sudo /usr/local/bin/proxyctl start $(sudo /usr/local/bin/proxyctl lookup \"" .. ngx.var.host .. "\")")
+    local status, exit, exit_code = os.execute("sudo -E /usr/local/bin/proxyctl start $(sudo /usr/local/bin/proxyctl lookup \"" .. ngx.var.host .. "\")")
 
     if (exit_code == 0) then
         -- If all went well, reload the page

--- a/conf/nginx/nginx.conf.tmpl
+++ b/conf/nginx/nginx.conf.tmpl
@@ -4,6 +4,9 @@ pid					/var/run/nginx.pid;
 daemon				off;
 
 env DEBUG_LOG;
+env PROJECT_INACTIVITY_TIMEOUT;
+env PROJECT_DANGLING_TIMEOUT;
+env PROJECT_AUTOSTART;
 
 # Send logs to stderr
 error_log /dev/stderr warn;


### PR DESCRIPTION
- Added `PROJECT_AUTOSTART` control switch (#63)
- Switched to `openresty/openresty:1.17.8.1-0-alpine` upstream image
- Avoid running into an empty upstream situation which resulted in a broken nginx config (#62)
- Ensure all containers are disconnected from a project's network before the network can be removed (#65)
