### PR TITLE
Build and test simplifications

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -163,16 +163,15 @@ jobs:
           docker version
           docker info
       -
-        name: Install Docksal
-        # This installs Docksal using the passed DOCKSAL_VERSION value
-        run: curl -sSL http://get.docksal.io | bash
-      -
-        # Reset vhost-proxy using the build image and prepare test project stacks
-        name: Prepare vhost-proxy testing
+        name: Test preparations
         working-directory: ${{ env.BUILD_CONTEXT }}
         env:
           BUILD_IMAGE_TAG: ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-${{ env.ARCH }}
-        run: make start
+        run: |
+          # This installs Docksal using the passed DOCKSAL_VERSION value
+          curl -sSL http://get.docksal.io | bash
+          # Reset vhost-proxy using the build image and prepare test project stacks
+          make start
       -
         # Run tests
         name: Test

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,7 +159,8 @@ jobs:
         # This installs Docksal using the passed DOCKSAL_VERSION value
         run: curl -sSL http://get.docksal.io | bash
       -
-        name: Prepare vhost-proxy for testsing
+        # Reset vhost-proxy using the build image and prepare test project stacks
+        name: Prepare vhost-proxy testing
         working-directory: ${{ env.BUILD_CONTEXT }}
         env:
           BUILD_IMAGE_TAG: ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-${{ env.ARCH }}

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -59,18 +59,24 @@ jobs:
           echo "GIT_SHA7=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
           echo "BUILD_CONTEXT=${VERSION:-.}" >> ${GITHUB_ENV}
           echo "BUILD_IMAGE_TAG=${IMAGE}:${VERSION_PREFIX}${VERSION}build" >> ${GITHUB_ENV}
+#      -
+#        # Switch docker context to a remote arm64 host
+#        # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
+#        name: Switch to arm64 builder host
+#        if: ${{ env.ARCH == 'arm64' }}
+#        uses: arwynfr/actions-docker-context@98fc92878d0b856c1112c79b8d0f45353206e186
+#        with:
+#          docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
+#          context_name: arm64-host
+#          ssh_key: "${{ secrets.ARM64_HOST_SSH_KEY }}"
+#          ssh_cert: "${{ secrets.ARM64_HOST_SSH_CERT }}"
+#          use_context: true
       -
-        # Switch docker context to a remote arm64 host
-        # TODO: try building/testing arm64 images with QEMU instead.
-        name: Switch to arm64 builder host
-        if: ${{ env.ARCH == 'arm64' }}
-        uses: arwynfr/actions-docker-context@98fc92878d0b856c1112c79b8d0f45353206e186
-        with:
-          docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
-          context_name: arm64-host
-          ssh_key: "${{ secrets.ARM64_HOST_SSH_KEY }}"
-          ssh_cert: "${{ secrets.ARM64_HOST_SSH_CERT }}"
-          use_context: true
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Check Docker
         run: |
@@ -90,6 +96,7 @@ jobs:
           context: ${{ env.BUILD_CONTEXT }}
           file: ${{ env.BUILD_CONTEXT }}/Dockerfile
           build-args: VERSION=${{ env.VERSION }}
+          platforms: linux/${{ env.ARCH }}
           # Push intermediate arch-specific build tag to repo
           tags: ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-${{ env.ARCH }}
           push: ${{ github.event_name != 'pull_request' }} # Don't push for PRs
@@ -140,6 +147,7 @@ jobs:
           echo "BUILD_IMAGE_TAG=${IMAGE}:${VERSION_PREFIX}${VERSION}build" >> ${GITHUB_ENV}
       -
         # Switch docker context to a remote arm64 host
+        # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
         name: Switch to arm64 builder host
         if: ${{ env.ARCH == 'arm64' }}
         uses: arwynfr/actions-docker-context@98fc92878d0b856c1112c79b8d0f45353206e186

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ DOCKSAL_VHOST_PROXY_STATS_LOG ?= 1
 PROJECT_INACTIVITY_TIMEOUT ?= 30s
 PROJECT_DANGLING_TIMEOUT ?= 60s
 
-# A delay necessary for docker-gen/nginx to reload configuration when containers start/stop.
-DELAY = 2s
+# A delay necessary for container and supervisord inside to initialize all services
+INIT_DELAY = 10s
+# A delay necessary for docker-gen to reload configuration when containers start/stop
+RELOAD_DELAY = 2s
 
 # Do not allow to override the value (?=) to prevent possible data loss on the host system
 PROJECTS_ROOT = $(PWD)/tests/projects_mount
@@ -51,7 +53,7 @@ start: clean
 	cp -R tests/certs ~/.docksal
 	IMAGE_VHOST_PROXY=$(BUILD_IMAGE_TAG) fin system reset vhost-proxy
 	# Give vhost-proxy a bit of time to initialize
-	sleep $(DELAY)
+	sleep $(INIT_DELAY)
 	# Stop crond, so it does not interfere with tests
 	make exec -e CMD='supervisorctl stop crond'
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Allow using a different docker binary
 DOCKER ?= docker
 
+# Force BuildKit mode for builds
+# See https://docs.docker.com/buildx/working-with-buildx/
+DOCKER_BUILDKIT=1
+
 IMAGE ?= docksal/vhost-proxy
 BUILD_IMAGE_TAG ?= $(IMAGE):build
 NAME = docksal-vhost-proxy

--- a/tests/projects/project1/.docksal/docksal.env
+++ b/tests/projects/project1/.docksal/docksal.env
@@ -1,1 +1,1 @@
-
+DOCKSAL_VOLUMES=disabled

--- a/tests/projects/project1/.docksal/docksal.yml
+++ b/tests/projects/project1/.docksal/docksal.yml
@@ -1,9 +1,17 @@
-version: "2.1"
+version: "3"
 
 services:
   web:
-    extends:
-      file: ${HOME}/.docksal/stacks/services.yml
-      service: nginx
-    environment:
-    - NGINX_VHOST_PRESET=html
+    image: hashicorp/http-echo:0.2.3
+    #network_mode: bridge # Use a shared bridge network
+    ports:
+      - 80
+    labels:
+      - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
+      - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
+      - io.docksal.project-root=${PROJECT_ROOT}
+      - io.docksal.virtual-port=80
+    command:
+      - '-listen=:80'
+      - '-text="Hello world: Project 1"'
+

--- a/tests/projects/project1/docroot/index.html
+++ b/tests/projects/project1/docroot/index.html
@@ -1,1 +1,0 @@
-Hello world: Project 1

--- a/tests/projects/project2/.docksal/docksal.env
+++ b/tests/projects/project2/.docksal/docksal.env
@@ -1,0 +1,1 @@
+DOCKSAL_VOLUMES=disabled

--- a/tests/projects/project2/.docksal/docksal.yml
+++ b/tests/projects/project2/.docksal/docksal.yml
@@ -1,12 +1,17 @@
-version: "2.1"
+version: "3"
 
 services:
   web:
-    extends:
-      file: ${HOME}/.docksal/stacks/services.yml
-      service: nginx
-    environment:
-    - NGINX_VHOST_PRESET=html
+    image: hashicorp/http-echo:0.2.3
+    #network_mode: bridge # Use a shared bridge network
+    expose:
+      - 80
     labels:
-    # Mark this stack as permanent, so that it's not removed during cleanup
-    - io.docksal.permanent=true
+      - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
+      - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
+      - io.docksal.project-root=${PROJECT_ROOT}
+      - io.docksal.virtual-port=80
+      - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
+    command:
+      - '-listen=:80'
+      - '-text="Hello world: Project 2"'

--- a/tests/projects/project2/docroot/index.html
+++ b/tests/projects/project2/docroot/index.html
@@ -1,1 +1,0 @@
-Hello world: Project 2

--- a/tests/projects/project3/.docksal/docksal.env
+++ b/tests/projects/project3/.docksal/docksal.env
@@ -1,0 +1,1 @@
+DOCKSAL_VOLUMES=disabled

--- a/tests/projects/project3/.docksal/docksal.yml
+++ b/tests/projects/project3/.docksal/docksal.yml
@@ -1,18 +1,17 @@
-version: "2.1"
+version: "3"
 
 services:
   web:
-    extends:
-      file: ${HOME}/.docksal/stacks/services.yml
-      service: nginx
+    image: hashicorp/http-echo:0.2.3
+    #network_mode: bridge # Use a shared bridge network
     expose:
-    # Expose a custom port
-    # A custom nginx vhost with this port is defined in .docksal/etc/nginx/vhosts.conf
-    - 2580
-    environment:
-    - NGINX_VHOST_PRESET=html
+      - 2580 # Custom port
     labels:
-    # Mark this stack as permanent, so that it's not removed during cleanup
-    - io.docksal.permanent=true
-    # Tell vhost-proxy to route to the custom port
-    - io.docksal.virtual-port=2580
+      - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
+      - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
+      - io.docksal.project-root=${PROJECT_ROOT}
+      - io.docksal.virtual-port=2580 # Tell vhost-proxy to route to the custom port
+      - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
+    command:
+      - '-listen=:2580' # Custom port
+      - '-text="Hello world: Project 3"'

--- a/tests/projects/project3/.docksal/etc/nginx/vhosts.conf
+++ b/tests/projects/project3/.docksal/etc/nginx/vhosts.conf
@@ -1,7 +1,0 @@
-server
-{
-    listen 2580;
-    server_name projec3.docksal;
-    root /var/www/docroot;
-    index index.html;
-}

--- a/tests/projects/project3/docroot/index.html
+++ b/tests/projects/project3/docroot/index.html
@@ -1,1 +1,0 @@
-Hello world: Project 3

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -304,17 +304,15 @@ _healthcheck_wait ()
 	${DOCKER} rm -vf standalone &>/dev/null || true
 	${DOCKER} run --name standalone -d \
 		--expose 2580 \
-		-e NGINX_VHOST_PRESET=html \
-		-v $(pwd)/tests/projects/project3:/var/www \
 		--label=io.docksal.virtual-host='standalone.docksal.site' \
 		--label=io.docksal.virtual-port='2580' \
-		docksal/nginx
+		hashicorp/http-echo:0.2.3 -listen=:2580 -text="Hello world: standalone"
 
 	# Wait for container to become healthy
 	_healthcheck_wait standalone
 
 	run curl -sS http://standalone.docksal.site
-	[[ "$output" =~ "Hello world: Project 3" ]]
+	[[ "$output" =~ "Hello world: standalone" ]]
 	unset output
 
 	# Cleanup
@@ -387,22 +385,23 @@ _healthcheck_wait ()
 	fin stop -a
 
 	# Start a standalone container
-	${DOCKER} rm -vf standalone &>/dev/null || true
-	${DOCKER} run --name standalone -d \
-		--label=io.docksal.virtual-host='nginx.example.com' \
-		docksal/nginx
+	name="standalone-cert1"
+	${DOCKER} rm -vf ${name} &>/dev/null || true
+	${DOCKER} run --name ${name} -d \
+		--label=io.docksal.virtual-host="${name}.example.com" \
+		hashicorp/http-echo:0.2.3 -text="Hello world: ${name}"
 
 	# Wait for container to become healthy
-	_healthcheck_wait standalone
+	_healthcheck_wait ${name}
 
 	# Check custom cert was picked up
 	run make conf-vhosts
-	[[ "$output" =~ "server_name nginx.example.com;" ]]
+	[[ "$output" =~ "server_name ${name}.example.com;" ]]
 	[[ "$output" =~ "ssl_certificate /etc/certs/custom/example.com.crt;" ]]
 	unset output
 
 	# Cleanup
-	${DOCKER} rm -vf standalone &>/dev/null || true
+	${DOCKER} rm -vf ${name} &>/dev/null || true
 }
 
 @test "Certs: proxy picks up custom cert based on cert name override [standalone container]" {
@@ -412,21 +411,22 @@ _healthcheck_wait ()
 	fin stop -a
 
 	# Start a standalone container
-	${DOCKER} rm -vf standalone &>/dev/null || true
-	${DOCKER} run --name standalone -d \
-		--label=io.docksal.virtual-host='apache.example.com' \
-		--label=io.docksal.cert-name='example.com' \
-		docksal/nginx
+	name="standalone-cert2"
+	${DOCKER} rm -vf ${name} &>/dev/null || true
+	${DOCKER} run --name ${name} -d \
+		--label=io.docksal.virtual-host="${name}.example.com" \
+ 		--label=io.docksal.cert-name='example.com' \
+		hashicorp/http-echo:0.2.3 -text="Hello world: ${name}"
 
 	# Wait for container to become healthy
-	_healthcheck_wait standalone
+	_healthcheck_wait ${name}
 
 	# Check server_name is intact while custom cert was picked up
 	run make conf-vhosts
-	[[ "$output" =~ "server_name apache.example.com;" ]]
+	[[ "$output" =~ "server_name ${name}.example.com;" ]]
 	[[ "$output" =~ "ssl_certificate /etc/certs/custom/example.com.crt;" ]]
 	unset output
 
 	# Cleanup
-	${DOCKER} rm -vf standalone &>/dev/null || true
+	${DOCKER} rm -vf ${name} &>/dev/null || true
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -122,7 +122,7 @@ _healthcheck_wait ()
 	fin @project2 project restart
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	run curl -sS -I http://project2.docksal.site
 	[[ "$output" =~ "HTTP/1.1 200 OK" ]]
@@ -197,7 +197,7 @@ _healthcheck_wait ()
 	fin @project2 project stop
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	run curl -sS http://project2.docksal.site
 	[[ "$output" =~ "Loading project..." ]]
@@ -218,7 +218,7 @@ _healthcheck_wait ()
 	fin @project2 project stop
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	run make curl -- -sSk https://project2.docksal.site
 	[[ "$output" =~ "Loading project..." ]]
@@ -331,7 +331,7 @@ _healthcheck_wait ()
 	fin @project2 project start
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	# Check fallback cert is used by default
 	run make conf-vhosts
@@ -344,7 +344,7 @@ _healthcheck_wait ()
 	fin @project2 project start
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	# Check custom cert was picked up
 	run make conf-vhosts
@@ -369,7 +369,7 @@ _healthcheck_wait ()
 	fin @project2 project start
 
 	# Give docker-gen and nginx a little time to reload config
-	sleep ${DELAY}
+	sleep ${RELOAD_DELAY}
 
 	# Check server_name is intact while custom cert was picked up
 	run make conf-vhosts


### PR DESCRIPTION
- Switched to `hashicorp/http-echo` image for testing (multi-arch image)
- Added `INIT_DELAY` wait in tests to let supervisord fully initialize
- Forcing BuildKit mode for builds
- Switched to building using QEMU. This image is lightweight, so QEMU build performance is not a concern.
- Moved Docksal installation into "Test preparation" step