### PR TITLE
Use native curl binary in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,6 @@ logs-follow:
 
 debug: build start logs-follow
 
-# Curl command with http2 support via a $(DOCKER) container
-# Usage: make curl -e ARGS='-kI https://docksal.io'
-curl:
-	$(DOCKER) run -t --rm --dns=192.168.64.100 --dns=8.8.8.8 badouralix/curl-http2 $(ARGS)
-
 clean:
 	fin @project1 rm -f &>/dev/null || true
 	fin @project2 rm -f &>/dev/null || true
@@ -94,7 +89,6 @@ clean:
 	$(DOCKER) rm -vf standalone &>/dev/null || true
 	rm -rf $(PROJECTS_ROOT)
 	rm -f ~/.docksal/certs/example.com.*
-
 
 # https://stackoverflow.com/a/6273809/1826109
 %:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -134,12 +134,12 @@ _healthcheck_wait ()
 	[[ ${SKIP} == 1 ]] && skip
 
 	# Non-existing project
-	run make curl -- -sSk -I https://nonsense.docksal.site
+	run curl -sSk -I https://nonsense.docksal.site
 	[[ "$output" =~ "HTTP/2 404" ]]
 	unset output
 
 	# Existing project
-	run make curl -- -sSk -I https://project2.docksal.site
+	run curl -sSk -I https://project2.docksal.site
 	[[ "$output" =~ "HTTP/2 200" ]]
 	unset output
 }
@@ -220,14 +220,14 @@ _healthcheck_wait ()
 	# Give docker-gen and nginx a little time to reload config
 	sleep ${RELOAD_DELAY}
 
-	run make curl -- -sSk https://project2.docksal.site
+	run curl -sSk https://project2.docksal.site
 	[[ "$output" =~ "Loading project..." ]]
 	unset output
 
 	# Wait for container to become healthy
 	_healthcheck_wait project2_web_1
 
-	run make curl -- -sSk https://project2.docksal.site
+	run curl -sSk https://project2.docksal.site
 	[[ "$output" =~ "Project 2" ]]
 	unset output
 }


### PR DESCRIPTION
Using badouralix/curl-http2 is no longer necessary. Since 7.47.0, the curl tool enables HTTP/2 by default for HTTPS connections