### PR TITLE
Switch echo image in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ clean:
 	fin @project3 rm -f &>/dev/null || true
 	$(DOCKER) rm -vf $(NAME) &>/dev/null || true
 	$(DOCKER) rm -vf standalone &>/dev/null || true
+	$(DOCKER) rm -vf standalone-cert1 &>/dev/null || true
+	$(DOCKER) rm -vf standalone-cert2 &>/dev/null || true
 	rm -rf $(PROJECTS_ROOT)
 	rm -f ~/.docksal/certs/example.com.*
 

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ clean:
 	$(DOCKER) rm -vf standalone &>/dev/null || true
 	$(DOCKER) rm -vf standalone-cert1 &>/dev/null || true
 	$(DOCKER) rm -vf standalone-cert2 &>/dev/null || true
-	rm -rf $(PROJECTS_ROOT)
-	rm -f ~/.docksal/certs/example.com.*
+	rm -rf $(PROJECTS_ROOT) &>/dev/null || true
+	rm -f ~/.docksal/certs/example.com.* &>/dev/null || true
 
 # https://stackoverflow.com/a/6273809/1826109
 %:

--- a/tests/projects/project1/.docksal/docksal.yml
+++ b/tests/projects/project1/.docksal/docksal.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
+    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
     ports:
       - 80
     labels:

--- a/tests/projects/project1/.docksal/docksal.yml
+++ b/tests/projects/project1/.docksal/docksal.yml
@@ -3,8 +3,7 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
-    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
-    ports:
+    expose:
       - 80
     labels:
       - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
@@ -12,5 +11,5 @@ services:
       - io.docksal.project-root=${PROJECT_ROOT}
       - io.docksal.virtual-port=80
     environment:
+      - PORT=80
       - "TEXT=Project 1"
-    command: ["--port 80"]

--- a/tests/projects/project1/.docksal/docksal.yml
+++ b/tests/projects/project1/.docksal/docksal.yml
@@ -2,8 +2,7 @@ version: "3"
 
 services:
   web:
-    image: hashicorp/http-echo:0.2.3
-    #network_mode: bridge # Use a shared bridge network
+    image: ealen/echo-server:0.5.1
     ports:
       - 80
     labels:
@@ -11,7 +10,6 @@ services:
       - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
       - io.docksal.project-root=${PROJECT_ROOT}
       - io.docksal.virtual-port=80
-    command:
-      - '-listen=:80'
-      - '-text="Hello world: Project 1"'
-
+    environment:
+      - "TEXT=Project 1"
+    command: ["--port 80"]

--- a/tests/projects/project2/.docksal/docksal.yml
+++ b/tests/projects/project2/.docksal/docksal.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
+    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
     ports:
       - 80
     labels:

--- a/tests/projects/project2/.docksal/docksal.yml
+++ b/tests/projects/project2/.docksal/docksal.yml
@@ -2,9 +2,8 @@ version: "3"
 
 services:
   web:
-    image: hashicorp/http-echo:0.2.3
-    #network_mode: bridge # Use a shared bridge network
-    expose:
+    image: ealen/echo-server:0.5.1
+    ports:
       - 80
     labels:
       - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
@@ -12,6 +11,6 @@ services:
       - io.docksal.project-root=${PROJECT_ROOT}
       - io.docksal.virtual-port=80
       - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
-    command:
-      - '-listen=:80'
-      - '-text="Hello world: Project 2"'
+    environment:
+      - "TEXT=Project 2"
+    command: ["--port 80"]

--- a/tests/projects/project2/.docksal/docksal.yml
+++ b/tests/projects/project2/.docksal/docksal.yml
@@ -3,8 +3,7 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
-    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
-    ports:
+    expose:
       - 80
     labels:
       - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
@@ -13,5 +12,5 @@ services:
       - io.docksal.virtual-port=80
       - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
     environment:
+      - PORT=80
       - "TEXT=Project 2"
-    command: ["--port 80"]

--- a/tests/projects/project3/.docksal/docksal.yml
+++ b/tests/projects/project3/.docksal/docksal.yml
@@ -14,4 +14,4 @@ services:
       - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
     environment:
       - "TEXT=Project 3"
-    command: ["--port 80"]
+    command: ["--port 2580"]

--- a/tests/projects/project3/.docksal/docksal.yml
+++ b/tests/projects/project3/.docksal/docksal.yml
@@ -3,7 +3,8 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
-    expose:
+    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
+    ports:
       - 2580 # Custom port
     labels:
       - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*

--- a/tests/projects/project3/.docksal/docksal.yml
+++ b/tests/projects/project3/.docksal/docksal.yml
@@ -2,8 +2,7 @@ version: "3"
 
 services:
   web:
-    image: hashicorp/http-echo:0.2.3
-    #network_mode: bridge # Use a shared bridge network
+    image: ealen/echo-server:0.5.1
     expose:
       - 2580 # Custom port
     labels:
@@ -12,6 +11,6 @@ services:
       - io.docksal.project-root=${PROJECT_ROOT}
       - io.docksal.virtual-port=2580 # Tell vhost-proxy to route to the custom port
       - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
-    command:
-      - '-listen=:2580' # Custom port
-      - '-text="Hello world: Project 3"'
+    environment:
+      - "TEXT=Project 3"
+    command: ["--port 80"]

--- a/tests/projects/project3/.docksal/docksal.yml
+++ b/tests/projects/project3/.docksal/docksal.yml
@@ -3,8 +3,7 @@ version: "3"
 services:
   web:
     image: ealen/echo-server:0.5.1
-    # Docker Compose v2 alpha3 (needed for arm64) has a bug with "expose", so we have to use "ports" instead
-    ports:
+    expose:
       - 2580 # Custom port
     labels:
       - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
@@ -13,5 +12,5 @@ services:
       - io.docksal.virtual-port=2580 # Tell vhost-proxy to route to the custom port
       - io.docksal.permanent=true # Mark this stack as permanent, so that it's not removed during cleanup
     environment:
+      - PORT=2580
       - "TEXT=Project 3"
-    command: ["--port 2580"]

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -293,7 +293,7 @@ _healthcheck_wait ()
 	_healthcheck_wait project3_web_1
 
 	run curl -sS http://project3.docksal.site
-	[[ "$output" =~ "Hello world: Project 3" ]]
+	[[ "$output" =~ "Project 3" ]]
 	unset output
 }
 
@@ -304,16 +304,17 @@ _healthcheck_wait ()
 	name="standalone"
 	${DOCKER} rm -vf ${name} &>/dev/null || true
 	${DOCKER} run --name ${name} -d \
-		--expose 2580 \
 		--label=io.docksal.virtual-host="${name}.docksal.site" \
 		--label=io.docksal.virtual-port="2580" \
-		hashicorp/http-echo:0.2.3 -listen=:2580 -text="Hello world: ${name}"
+		--env "TEXT=${name}" \
+		--expose 2580 \
+		ealen/echo-server:0.5.1 --port=2580
 
 	# Wait for container to become healthy
 	_healthcheck_wait ${name}
 
 	run curl -sS "http://${name}.docksal.site"
-	[[ "$output" =~ "Hello world: ${name}" ]]
+	[[ "$output" =~ "${name}" ]]
 	unset output
 
 	# Cleanup
@@ -390,7 +391,8 @@ _healthcheck_wait ()
 	${DOCKER} rm -vf ${name} &>/dev/null || true
 	${DOCKER} run --name ${name} -d \
 		--label=io.docksal.virtual-host="${name}.example.com" \
-		hashicorp/http-echo:0.2.3 -text="Hello world: ${name}"
+		--env "TEXT=${name}" \
+		ealen/echo-server:0.5.1 --port=2580
 
 	# Wait for container to become healthy
 	_healthcheck_wait ${name}
@@ -417,7 +419,8 @@ _healthcheck_wait ()
 	${DOCKER} run --name ${name} -d \
 		--label=io.docksal.virtual-host="${name}.example.com" \
  		--label=io.docksal.cert-name='example.com' \
-		hashicorp/http-echo:0.2.3 -text="Hello world: ${name}"
+		--env "TEXT=${name}" \
+		ealen/echo-server:0.5.1 --port=2580
 
 	# Wait for container to become healthy
 	_healthcheck_wait ${name}


### PR DESCRIPTION
Switched to ealen/echo-server image for testing. This one is multi-arch (unlike hashicorp/http-echo).