### PR TITLE
proxyctl lookup: match any vhost

### DIFF
--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -57,7 +57,6 @@ lookup ()
 		if [[ "$container_id" == "" ]]; then
 			# Get a list of all (running and stopped) projects and their virtual host label values
 			local all_projects=$(docker ps -a \
-				--filter "label=io.docksal.project-root" \
 				--filter "label=io.docksal.virtual-host" \
 				--format '{{ .ID }}:{{.Label "com.docker.compose.project"}}:{{.Label "io.docksal.virtual-host"}}')
 


### PR DESCRIPTION
Removing the `label=io.docksal.project-root` filter from the lookup function allows secondary project vhosts to trigger autostart. This is especially useful for stacks with Coder IDE enabled, so that the default pattern `ide-PROJECT.domain` works seamlessly.

I've not encountered a use-case where removing the `project-root` filter like this creates problems; it seems the search on the `io.docksal.virtual-host` label should be sufficient.