### PR TITLE
Update TLS server settings

### DIFF
--- a/conf/nginx/nginx.conf.tmpl
+++ b/conf/nginx/nginx.conf.tmpl
@@ -41,9 +41,11 @@ http {
 		ssl_certificate_key			/etc/certs/server.key;
 
 		ssl_session_cache			builtin:1000  shared:SSL:10m;
-		ssl_protocols				TLSv1 TLSv1.1 TLSv1.2;
-		ssl_ciphers					HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-		ssl_prefer_server_ciphers	on;
+
+		# Using recommended settings from https://ssl-config.mozilla.org/#server=nginx&config=intermediate
+		ssl_protocols				TLSv1.2 TLSv1.3;
+		ssl_ciphers					ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+		ssl_prefer_server_ciphers	off;
 
 		location / {
 			# See https://github.com/openresty/lua-nginx-module#ngxeof


### PR DESCRIPTION
- Dropped legacy protocols (TLSv1, TLSv1.1)
- Using recommended settings from https://ssl-config.mozilla.org/#server=nginx&config=intermediate

Fixes #83