### PR TITLE
Version bumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.19.3.2-1-alpine
+FROM openresty/openresty:1.19.9.1-5-alpine
 
 # amd64 / arm64
 ARG TARGETARCH
@@ -16,9 +16,9 @@ RUN set -xe; \
 	addgroup -S nginx; \
 	adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 
-ARG DOCKER_VERSION=20.10.7
-ARG DOCKER_GEN_VERSION=0.7.6
-ARG GOMPLATE_VERSION=3.0.0
+ARG DOCKER_VERSION=20.10.12
+ARG DOCKER_GEN_VERSION=0.8.2
+ARG GOMPLATE_VERSION=3.10.0
 
 # Install docker client binary (if not mounting binary from host)
 RUN set -xe; \


### PR DESCRIPTION
- base image - openresty/openresty:1.19.9.1-5-alpine
- docker v20.10.12
- docker-gen v0.8.2
- gomplate v3.10.0