### PR TITLE
"Project autostart disabled" screen

### DIFF
--- a/bin/proxyctl
+++ b/bin/proxyctl
@@ -89,13 +89,40 @@ lookup ()
 			log "ERROR: No matching projects or containers found for virtual host '${vhost}'."
 			return 1
 		else
-			log "Found a standalone container '$container_id'..."
+			log "${vhost} belongs to ${container_id} (container)"
+			# Return value to be passed to start(type, id)
 			echo "container ${container_id}"
 		fi
 	else
-		log "Found a project stack '$project_name'..."
+		log "${vhost} belongs to ${project_name} (project)"
+		# Return value to be passed to start(type, id)
 		echo "project ${project_name}"
 	fi
+}
+
+# HTTP request handler for nginx
+# Looks up a container or project by Host (passed from nginx) and starts it up.
+# Skips start if autostart is disabled
+# Return codes:
+# 0 - nginx will return a "Project loading" screen, but no project will be loaded in this case.
+# 1 - nginx will return a "Project not found" screen.
+# 2 - nginx will return a "Project autostart disabled" screen.
+# See conf/nginx/lua/proxyctl.lua
+wakeup ()
+{
+	host=${1}
+	# Return 1 if lookup failed
+	id=$(lookup "${host}") || exit 1
+
+	log "Matched ${host} to ${id}"
+
+	# Skip if autostart is disabled
+	if [[ "$PROJECT_AUTOSTART" == 0 ]]; then
+		log "Skipping autostart for: ${id} (autostart is disabled)"
+		exit 2
+	fi
+
+	start ${id} && exit 0 || exit 1
 }
 
 start ()
@@ -103,22 +130,19 @@ start ()
 	# Set logging prefix for the function and trigger a log entry
 	export LOG_PREFIX='[start]' && log
 
-	# Disable projects autostart in case PROJECT_AUTOSTART set to 0
-	[[ "$PROJECT_AUTOSTART" == 0 ]] && log "WARNING: Projects autostart is disabled." && return 0
-
-	local type=${1}
-	local id=${2}
+	local type=${1} # "container" or "project"
+	local id=${2} # container id or project name
 
 	[[ "$type" == "" ]] && log "ERROR: Empty type." && return 1
 	[[ "$id" == "" ]] && log "ERROR: Empty id." && return 1
 
 	if [[ "$type" == "container" ]]; then
 		local container_id=${id}
-		log "Starting a standalone container '$container_id'..."
-		docker start "$container_id"
+		log "Starting ${container_id} (container)..."
+		docker start ${container_id}
 	elif [[ "$type" == "project" ]]; then
 		local project_name=${id}
-		log "Starting project stack for '${project_name}'..."
+		log "Starting ${project_name} (project)..."
 
 		# Connecting/re-connecting vhost-proxy to the project network
 		local network="${project_name}_default"
@@ -127,7 +151,7 @@ start ()
 		# Reconnect vhost-proxy to the project network (in case vhost-proxy has been recently reset)
 		docker network connect "$network" docksal-vhost-proxy >/dev/null 2>&1
 		if [[ $? == 0 ]]; then
-			log "Connected proxy to network '${network}'."
+			log "Connected proxy to ${network} network."
 		fi
 
 		# Reconnect project containers to the re-created network
@@ -399,6 +423,10 @@ case "$1" in
 		shift
 		lookup "$@"
 		;;
+	wakeup)
+		shift
+		wakeup "$@"
+		;;
 	start)
 		shift
 		start "$@"
@@ -422,5 +450,5 @@ case "$1" in
 		stats
 		;;
 	*)
-		echo "Usage: $0 lookup <vhost>|start|stop|cron|notify|networks|cleanup|stats"
+		echo "Usage: $0 lookup <vhost>|wakeup <vhost>|start|stop|cron|notify|networks|cleanup|stats"
 esac

--- a/conf/nginx/lua/proxyctl.lua
+++ b/conf/nginx/lua/proxyctl.lua
@@ -15,6 +15,11 @@ local function read_file(path)
     return content
 end
 
+-- Only allow letters, digits, hyphens, and periods in host name
+local function safe_host(str)
+    return string.gsub(str, "[^%a%d%-%.]", "")
+end
+
 -- Returns loading.html for HTTP_OK and not-found.html otherwise
 local function response(status)
     -- Load response body from disk
@@ -34,31 +39,33 @@ local function response(status)
     ngx.print(response_body)
 
     -- Unlock host before exiting
-    dpr("Unlocking " .. ngx.var.host)
-    ngx.shared.hosts:delete(ngx.var.host)
+    local host = safe_host(ngx.var.host)
+    dpr("Unlocking " .. host)
+    ngx.shared.hosts:delete(host)
 
     return ngx.exit(status)
 end
 
 -- Get the host lock timestamp
+local host = safe_host(ngx.var.host)
 local timestamp = os.time(os.date("!*t"))
-local lock_timestamp = ngx.shared.hosts:get(ngx.var.host)
+local lock_timestamp = ngx.shared.hosts:get(host)
 
 if (lock_timestamp == nil) then lock_timestamp = 0 end
 local lock_age = timestamp - lock_timestamp
 
 if (lock_age > 30) then
     -- Break the lock if it is older than 30s
-    dpr("Unlocking a stale lock (" .. lock_age .. "s) for " .. ngx.var.host)
-    ngx.shared.hosts:delete(ngx.var.host)
+    dpr("Unlocking a stale lock (" .. lock_age .. "s) for " .. host)
+    ngx.shared.hosts:delete(host)
 end
 
 if (lock_timestamp == 0) then
     -- No lock timestamp = can proceed with project wake up
 
-    dpr("Locking " .. ngx.var.host)
+    dpr("Locking " .. host)
     lock_timestamp = os.time(os.date("!*t"))
-    ngx.shared.hosts:set(ngx.var.host, lock_timestamp)
+    ngx.shared.hosts:set(host, lock_timestamp)
 
     -- Lanch project start script
     -- os.execute returs multiple values starting with Lua 5.2
@@ -75,5 +82,5 @@ if (lock_timestamp == 0) then
     end
 else
     -- There is an active lock, so skip for now
-    dpr(ngx.var.host .. " is locked. Skipping.")
+    dpr(host .. " is locked. Skipping.")
 end

--- a/www/406.html
+++ b/www/406.html
@@ -1,0 +1,58 @@
+<html>
+<head>
+    <title>Docksal :: Project autostart disabled </title>
+    <style>
+        html, body {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: #f9f9f9;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            color: #000;
+        }
+        div#flex {
+            display: flex;
+        }
+        div#sign {
+            width: 150px;
+            height: 150px;
+        }
+        div#title {
+            font-size: xx-large;
+            margin-bottom: 1em;
+            padding: 15px 20px;
+        }
+        div#description {
+            padding: 0 20px;
+        }
+        .small {
+            font-size: small;
+        }
+        code {
+            font-family: 'Courier New', Courier, monospace
+        }
+    </style>
+</head>
+<body>
+<div id="flex">
+    <div id="sign">
+        <svg width="150px" height="150px" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
+            <path transform="matrix(5.1965 0 0 5.3726 -738.86 -644.43)"
+                  d="m324.45 213.01a86.051 83.23 0 1 1 -172.1 0 86.051 83.23 0 1 1 172.1 0z" fill="none" stroke="#f00"
+                  stroke-width="20"/>
+            <path d="m166.83 166.83 666.33 666.33" fill="none" stroke="#f00" stroke-width="100"/>
+        </svg>
+    </div>
+    <div id="text">
+        <div id="title">Project autostart disabled</div>
+        <div id="description">
+            <p>This domain maps to a stopped project which cannot be started.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Added "Project autostart disabled" screen
  - Displayed when autostart of a stopped project stack not allowed (vhost-proxy was started with `PROJECT_AUTOSTART=0`)
  - Returns `HTTP_NOT_ACCEPTABLE` (`406`) return code
- Safe `ngx.var.host` variable handling
