### PR TITLE
Release 1.8.1

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -64,7 +64,7 @@ jobs:
 #        # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
 #        name: Switch to arm64 builder host
 #        if: ${{ env.ARCH == 'arm64' }}
-#        uses: arwynfr/actions-docker-context@98fc92878d0b856c1112c79b8d0f45353206e186
+#        uses: arwynfr/actions-docker-context@v2
 #        with:
 #          docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
 #          context_name: arm64-host
@@ -150,7 +150,7 @@ jobs:
         # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
         name: Switch to arm64 builder host
         if: ${{ env.ARCH == 'arm64' }}
-        uses: arwynfr/actions-docker-context@98fc92878d0b856c1112c79b8d0f45353206e186
+        uses: arwynfr/actions-docker-context@v2
         with:
           docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
           context_name: arm64-host

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ RUN set -xe; \
 	rm $DOCKER_GEN_TARFILE
 
 # Install gomplate
+# IMPORTANT: DO NOT used the "slim" version - it's broken on arm64.
 RUN set -xe; \
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-${TARGETARCH}-slim -o /usr/local/bin/gomplate; \
+	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-${TARGETARCH} -o /usr/local/bin/gomplate; \
 	chmod +x /usr/local/bin/gomplate
 
 RUN set -xe; \

--- a/conf/nginx/nginx.conf.tmpl
+++ b/conf/nginx/nginx.conf.tmpl
@@ -87,8 +87,8 @@ http {
 	proxy_buffers			4 256k;
 	proxy_busy_buffers_size	256k;
 
-	# Allow large POSTs
-	client_max_body_size	500M;
+	# Disable limits to avoid "HTTP 413 (Request Entity Too Large)" for large uploads
+	client_max_body_size	0;
 
 	# Fixes random issues with POST requests
 	# See https://github.com/dockerfile/nginx/issues/4#issuecomment-209440995


### PR DESCRIPTION
- Switch to the standard `gomplate` binary (not slim)
  - The "slim" version is broken on arm64
- Disable upload limits to avoid "HTTP 413 (Request Entity Too Large)"
